### PR TITLE
Change v-is-authorized to v-if-authorized

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ function plugin(Vue, options) {
     return
   }
 
-  Vue.directive('isAuthorized', IsAuthorizedDirective)
+  Vue.directive('ifAuthorized', IsAuthorizedDirective)
   Vue.component('isAuthorized', IsAuthorizedComponent)
 
   let vueAuthorizeInstance = null


### PR DESCRIPTION
The plugin registers a "v-is-authorized" directive despite all documentation showing that it should be "v-if-authorized". Changed the directive registration to match the README.